### PR TITLE
Return notification when calling fn directly

### DIFF
--- a/dist/notify.js
+++ b/dist/notify.js
@@ -538,10 +538,11 @@
 	$[pluginName] = function(elem, data, options) {
 		if ((elem && elem.nodeName) || elem.jquery) {
 			$(elem)[pluginName](data, options);
+			return $(elem).data('notifyjs-curr');
 		} else {
 			options = data;
 			data = elem;
-			new Notification(null, data, options);
+			return new Notification(null, data, options);
 		}
 		return elem;
 	};
@@ -553,6 +554,7 @@
 				prev.destroy();
 			}
 			var curr = new Notification($(this), data, options);
+			$(this).data('notifyjs-curr', curr);
 		});
 		return this;
 	};


### PR DESCRIPTION
Just found this fork lurking in a package.json from a while back and thought it might be useful...

Returns the notification object when calling `fn` directly, allowing us to resize the notification container. I was doing this to automatically resize the notification container based on text width + some arbitrary offset.